### PR TITLE
update_dns_head: validate that provided link is a formally correct DNS link

### DIFF
--- a/scripts/update_dns_head.py
+++ b/scripts/update_dns_head.py
@@ -1,6 +1,9 @@
 import os
+import re
 import json
 import requests
+
+dnslink_re = re.compile("^/(?P<namespace>[^/]+)/(?P<identifier>.+)$")
 
 
 def get_config_dir():
@@ -55,12 +58,19 @@ class DNSApi:
         res.raise_for_status()
 
 
+def is_valid_dnslink(link):
+    return dnslink_re.match(link) is not None
+
+
 def main():
     import argparse
 
     parser = argparse.ArgumentParser()
     parser.add_argument("ipfs_link", help="IPFS link, e.g.: /ipfs/CID")
     args = parser.parse_args()
+
+    if not is_valid_dnslink(args.ipfs_link):
+        raise ValueError(f"The provided link ('{args.ipfs_link}') is not a valid dnslink. Did you forget the prefix '/ipfs/' before a CID? See https://dnslink.io for more info.")
 
     api = DNSApi()
 


### PR DESCRIPTION
Previously, I added just the CID (and not `/ipfs/<CID>`) as a dnslink entry, which is not correct (but apparently supported by kubo). As there might be other implementations which behave differently, we should try to match the spec, validating the input will help not forgetting this.