### PR TITLE
New level 2 version. No interpolation, only binning. ...

### DIFF
--- a/pinlist.yaml
+++ b/pinlist.yaml
@@ -518,3 +518,9 @@
     prev: QmWKXT5T1CsFe9jyJWwjnbkMTag75j8bAGmGZ8zt69EHBy
     tags:
     - all
+- cid: QmNUqnfu7dDYFn6MjRq5wC4EJNNtNDiX5XFShuREMiLuMF
+  name: ORCESTRA HEAD v84
+  meta:
+    prev: QmYqKyecLfgz3wKFjcJWpio9m6yibgDxou8MSseXLXcUDR
+    tags:
+    - all

--- a/tree.yaml
+++ b/tree.yaml
@@ -146,8 +146,8 @@ products:
       v1.0.zarr: Qmbnt4feM7NF2zrWfTNkmpyiFBErCDseyi1TsiG2EeEP2r
       v2.0.zarr: QmPJuf78jNiMfmLxhM38ygbYu3kNWSXpHwNPsi8YiTn6wA
   Radiosondes:
-    RS_ORCESTRA_level2.zarr: QmdZhmUmkjQhr6N5LHsPMpTCLr6ft14FMxpK8xtsfcp5dn
-    RS_Oscillating_ORCESTRA_level1.zarr: Qmc2EnSQJvXiP2TrQqd3jdoEaaMewq2iL9iPjUzjrezerE
+    RAPSODI_RS_ORCESTRA_level2.zarr: QmbZQh6TcKVaWLj2x5UxqJ2nWcY3He1qwpsVQjCcUip7wq
+    RAPSODI_RS_Oscillating_ORCESTRA_level1.zarr: QmREhndxVvKtYpjRGnmQwRsQrjdfE5qkWxnTEpoU1TEEwW
 
 raw:
   HALO:


### PR DESCRIPTION
New level 2 version. No interpolation, only binning in accordance to the dropsonde.
New attributes in level 1 osc_ds. Therefore new CIDs.