### PR TITLE
Add auxiliary GSMaP dataset to pinlist

### DIFF
--- a/pinlist.yaml
+++ b/pinlist.yaml
@@ -524,3 +524,8 @@
     prev: QmYqKyecLfgz3wKFjcJWpio9m6yibgDxou8MSseXLXcUDR
     tags:
     - all
+- cid: QmfQ9fPDSU5Q5qMsPbSZ2cq9mF1vMGp1Zi5pZ2sa1WLBnB
+  name: Subset of GSMaP (v4) MVK-Gauge hourly data v1
+  meta:
+    tags:
+    - aux

--- a/pinlist.yaml
+++ b/pinlist.yaml
@@ -524,7 +524,7 @@
     prev: QmYqKyecLfgz3wKFjcJWpio9m6yibgDxou8MSseXLXcUDR
     tags:
     - all
-- cid: QmfQ9fPDSU5Q5qMsPbSZ2cq9mF1vMGp1Zi5pZ2sa1WLBnB
+- cid: QmU9ShLg6NgWG2VxYddgWjynUYZtZvfw1EBFHtPAwmWjYK
   name: Subset of GSMaP (v4) MVK-Gauge hourly data v1
   meta:
     tags:


### PR DESCRIPTION
This is an alternative approach and thus closes #65 