### PR TITLE
Extend BOW-TIE

### DIFF
--- a/pinlist.yaml
+++ b/pinlist.yaml
@@ -563,4 +563,9 @@
   meta:
     tags:
     - eurec4a
-  
+- cid: QmfYnK3SyugMJXQZfDKtooUxPNWeodhqVCtcetQ5ETYket
+  name: ORCESTRA HEAD v89
+  meta:
+    prev: QmPLxctRGhRvnm1TEXmPhdTC7G2WXQTjyQLy11FYR8SCVw
+    tags:
+    - all

--- a/tree.yaml
+++ b/tree.yaml
@@ -123,6 +123,7 @@ products:
     ISAR_SST.zarr: QmQnG9B21YCJUbvb1o15iyJobwQQMAx3pFxHr412CMUTwU
     LICHT-LIDAR_b.zarr: QmVJU8nqwBTB7dxbHvs7SL5v4LjdiD3792n4e1p1dBrtyQ
     LICHT-LIDAR_t.zarr: QmZ6y4t1UQ4JgrNtcpnSTdX2uxeN2hsfodDDfJQETAdBzB
+    mrr_rainflag.zarr: QmYkt6UkTR7e3i8C2LDyzMEwimd85enW9hn3ntbH9YcpXH
     rain_gauge:
       Hinweise_und_Abkuerzungen.txt: bafkreifh66ejafyu2yrpz63zmavdpgbf7sihnr7svosujhladvp2paiswa
       M203_Niederschlag_Stand_240923-2227.log: QmdxMqRNRKrp9sWPCumSRMoaBKKAMTASSymYVUDswokH73

--- a/tree.yaml
+++ b/tree.yaml
@@ -115,7 +115,11 @@ products:
       DSD_METEOR_merged.zarr: Qme2WqrMLvY6gtuBgrfoymNgVAinKqmJzENrbcGA5zFax9
     DShip.zarr: QmSSrT1UdtocfQS5yWSHFEJwJjqcNXjq2F1QfvNgLuEqSN
     GNSS_IWV.zarr: QmZ8qAy5TAideiPua2Ri2DwU1rRfZjiGLJkbSzJDN2bfxA
-    HATPRO-single.zarr: QmRkg2HvADeQTmrDZvadWPgiLxV2A1SborgfbPFwRPzGCd
+    HATPRO:
+      hatpro_multi_part1.zarr: QmZHV4jQkPhPKP8CWoTSm47pMrzjoaJ5kbrB4jHZFvHhkN
+      hatpro_multi_part2.zarr: QmQuEa46ApH7sxuEsvJEbCy8rFXh7bGAmV1GUyJf7eoCxk
+      hatpro_single_part1.zarr: QmQnEdGm2P86hURFmh8MWQZQbBRwyHG6cUrKgRoeoAQZ9N
+      hatpro_single_part2.zarr: QmUUiddsAx14WE3SP5FXJD935zvuVnsAECUuudyWnuBkkU
     ISAR_SST.zarr: QmQnG9B21YCJUbvb1o15iyJobwQQMAx3pFxHr412CMUTwU
     LICHT-LIDAR_b.zarr: QmVJU8nqwBTB7dxbHvs7SL5v4LjdiD3792n4e1p1dBrtyQ
     LICHT-LIDAR_t.zarr: QmZ6y4t1UQ4JgrNtcpnSTdX2uxeN2hsfodDDfJQETAdBzB

--- a/tree.yaml
+++ b/tree.yaml
@@ -104,6 +104,7 @@ products:
     ceilometer:
       CHM170158.zarr: QmaAiM55c9dB2zWBuoUsrb2DPycznFFEKZrVZvDt2uuuEJ
     cloudcamera: QmfAjwquv4iXijQe9QZ3TmwCPHnh8riSL5XBRy863gAyqQ
+    cloudnet.zarr: QmSw6jc9FrcY6tcnKw2bvHJ2NYwS5WwRjSsPxNM4fcVvTr
     CTD.zarr: QmeNTnoRcQ6bjs7XnT6eD1thazv4ct8GnECF57zn4fq2RZ
     disdrometer:
       Disdro_README_ORCESTRA.pdf: QmZm7BXUsDbHXgxD4aUUR7WgQ4rSQojXjDMQn7kagXt6BY


### PR DESCRIPTION
This PR:
* updates the HATPRO datasets
  * for now, the dataset is split into Part 1 and 2 of the campaign, because the height coordinate changed on August 22
* adds Cloudnet products
* adds a time series of the MRR rain flag