### PR TITLE
Add SMART

### DIFF
--- a/pinlist.yaml
+++ b/pinlist.yaml
@@ -610,3 +610,9 @@
     prev: Qmb1wKeNLkqichCfPwsjk8f2vBHU1dxkgLRVmHwk7rdvi2
     tags:
     - all
+- cid: QmfW3DWrko9SLQjG1bSJf5Sv2Z3AvwDJZVVdVsLdzZgdEj
+  name: ORCESTRA HEAD v92
+  meta:
+    prev: QmbVqUTPvZQa3rGxBTG286PtCHCGgzgc9uK7x2YGYm148z
+    tags:
+    - all

--- a/tree.yaml
+++ b/tree.yaml
@@ -98,6 +98,9 @@ products:
       HALO-20240924a.mp4: QmSScNDjmxxfakVR1yypTBVaFcuMKYptjAwKhgNyB3vFbV
       HALO-20240926a.mp4: QmYaCACmcNZouayGMiF2g3KxsiWyvS885jaChwsjg3at2e
       HALO-20240928a.mp4: QmPgtTarn3wE5xosXN86HVwsSuDK915gUjEDTWbZ56pRrK
+    SMART:
+      Fup.zarr: bafybeia4winn7xzqchcss3ilgoyxj2rakdzrv3eswcbol5rsqgcku34zzu
+      Iup.zarr: bafybeig34sqju7y3vp7qeughc2bhr6lnjd3rcr7xm7az5duj74qybozlr4
   METEOR:
     ADCP:
       met_203_vmadcp_38khz.zarr: QmXiL1DBihoVRbomunkrH5yWbz9hH6JekjvcPDQujnkgoa


### PR DESCRIPTION
This is a merged and re-stacked version of the SMART dataset published on the HALO DB.

It is apparently missing some flight days, which may or may not be added in the future. The two datasets are only about 80MB in size, so I think we can afford to add now and update later (even if most of the data chunks will be rewritten).