### PR TITLE
updated dropsondes

### DIFF
--- a/tree.yaml
+++ b/tree.yaml
@@ -108,8 +108,7 @@ products:
         PERCUSION_Level_4.zarr: QmNakbb4wSSfwduA46KrfzWcHHJyiQL5yKskocFz5GNmVW
       Level_3:
         PERCUSION_Level_3.zarr: QmTDWBBAzQ8RsK1hBDHKLJvxZozXJ4DBr4YLWndcFHkuyj
-        PERCUSION_Level_3_qc.zarr: 
-          QmUCGP3LM6bpQKfXh8eFBMYUL8oawHPxhrBvDp4u3jqX6b
+        PERCUSION_Level_3_qc.zarr: QmUCGP3LM6bpQKfXh8eFBMYUL8oawHPxhrBvDp4u3jqX6b
     flight_animations:
       HALO-20240811a.mp4: QmZq3bWjAAMnU96WzwG79aNdVDRJsiJYohaTX3ELGDUhfF
       HALO-20240813a.mp4: QmZvPRwxJS78imNvBxYaXZUGzggcywpN4TaXRQy3tJJruH


### PR DESCRIPTION
This PR updates the dropsonde data, including 
- a bug fix in the sonde profiles in level 4 (some were assigned wrong)
- recalculation of ta and rh after interpolation in level 4
- interpolation/extrapolation of $p$, $q$, and ta before IWV calculation in Level 3
- time encoding change. 
- renaming of `aircraft_latitude` -> `launch_lat`, `aircraft_longitude` -> `launch_lon`, `aircraft_msl_altitude` -> `aircraft_altitude` (to align a bit better with RAPSODI/GATE naming). 

car file is found at `/scratch/m/m301046/QmfPP8c4qbmqo6cRU6TqYoA5emqkgUZk9rWdi1RQUTd9Kk.car`.

new head: QmcCtsAR7Ssav1Q5H95MDnTiJZdPTaD3g8pzPDV5BvZ3dP

It would be great if you could check the time encoding, because I am not 100% sure that that's correct now... 