### PR TITLE
add l1 dataset metadata

### DIFF
--- a/pinlist.yaml
+++ b/pinlist.yaml
@@ -717,3 +717,9 @@
     prev: QmSkB8vMm2dYgmLvMYgQFv4RBcjMzgJivttzyogzm4M5wR
     tags:
     - all
+- cid: QmUTpY6aHJNSatB6oQZTxsd7b4QkEGCpPdLvQzwF4ECJJo
+  name: ORCESTRA HEAD v108
+  meta:
+    prev: QmceUMq56SS3BFFrn151YqiXH89PHsrFQcLDH8ZRb77KUf
+    tags:
+    - all

--- a/tree.yaml
+++ b/tree.yaml
@@ -54,61 +54,11 @@ products:
         full_radar.zarr: Qmc5T6i5Vnx27fdyU3oF2gjqqS7QHTkMjyVDZRW24tXZKe
         full_radiometer.zarr: bafybeigmb3ngfpq2yxbx5yzr34ggdb3va4jibycqra37thtlbakqxjhoza
     dropsondes:
-      Level_1:
-        HALO-20240809b: Qmb3pvCCZFdQwKeoxskQiyfguLZBs4UWVE6iAeSwaGRvo7
-        HALO-20240811a: QmcHmgEaTG6QjHT8AXi5MfP9EgMYgecqfgBvKntBFjdNxc
-        HALO-20240813a: QmUZnFCTR4vB2uSW52MUn1gwvwnb2VEzHd5rTjDq9xjHEr
-        HALO-20240816a: QmZXrJ1E9u8B3dZGQruHphZTxRSW6iKDcJKvAxwNng4vD9
-        HALO-20240818a: QmT77VLooDAn4n7mbTFoin7PwzygVhtHknJXWiUCPEFm9C
-        HALO-20240821a: QmQ3EF19gYPExAE94UVCXpXsAjxVUynSJ5Q2SCceA9N7Rh
-        HALO-20240822a: QmUhWLhK45DJzieCr7vJJThnqSkWpz1ix9WZQ6AiW9yL4q
-        HALO-20240825a: QmVwWoUcvX1mgyh85RmjYB29iLJrnj5zCJSYqHpevWcJCE
-        HALO-20240827a: QmehyUEXXSyJ3WMtgm65xo1La9AvezFGvT1Sz84c55zQUM
-        HALO-20240829a: QmTxTuEVTJtNTXz7PMd7r4QGCL15weLpupm66phyaztnhC
-        HALO-20240831a: QmaqtqpP3XEQwZMupYAK1qfgWTdUP93oNbpNrpvcuR1yr2
-        HALO-20240903a: QmVQEvb1mLARkqdkECHutfBgJr5NAwcdwgBMFDTpEiN878
-        HALO-20240906a: QmSdQkm5XuwY9m8HTPg7Uh4hA74qhAxZpqguRQvgquByCw
-        HALO-20240907a: QmdqBPyYqvHJPtnUiT7ptnAqjYdMDDAWjq2RfvLjvQFjGx
-        HALO-20240909a: QmeixN1PBRWUKJhJNdW5G2Q7DSSqobWxfpb8us3dixE9J3
-        HALO-20240912a: QmawkNGnW2Qv2Fr5UgWXMRc22EvzvfP6cBQxNXMRBEJtVR
-        HALO-20240914a: QmWrg1nmqrMAiLBVyqKACu3Hg21LKS3ws7MMvy5BRT2eTp
-        HALO-20240916a: QmZs6xruYUDgxyNtQDCA7i8HaDeChG1kUMe7B16bPxXRDy
-        HALO-20240919a: QmcNWqhkJG2399tgFtZAyv3F9nYeGEwM8GhNELq7STY2aJ
-        HALO-20240921a: QmZVgs6quRFEKWPvcCVfaQACo4R1ETyYGNKspBxq5XGhUF
-        HALO-20240923a: QmUHNQpcerjwieQv69aBYc1owe5576oDTtw5jvCjH1jhjQ
-        HALO-20240924a: QmP8sWYSt9LmHBGDBmouBNySv5NV6r6a5hoF6sY8PTfWKo
-        HALO-20240926a: QmZkVrgvsAUfTx5GWKrpeZhFPWrx7vefcdah99y3kV88To
-        HALO-20240928a: QmSn1U47u8VQNYwgEFKRk4VsmCYnkeMKweusFGuyTgyXSe
-      Level_2:
-        HALO-20240809b: QmXUSh7MpQTutv1drXBtmfHHoa2ZeSpxjVZ8hEYJwMR875
-        HALO-20240811a: QmUsCqGoCg8gQSCmGz8XNb6v2Nz2ypxUkPSWmXpVfMz9Mf
-        HALO-20240813a: QmRxGqHFinLjmQvm3sDfrP69ZDn9LEa4nozZthMLNs33Ey
-        HALO-20240816a: QmSPXXerYeGQegvLc7siduC9Ms9VcYfXEo2JZEYW2Cf4ja
-        HALO-20240818a: QmVxufRRWQ3LHgFnVASDyXzSozH6CXjjSTtCoUKoyLmdKs
-        HALO-20240821a: QmeUhGLkevJqtrotRVJZoGKtLendso6gzvazPWazSdrqLG
-        HALO-20240822a: QmTCJz3Rd3tZT7ME8zPHAP8qZN21AesvCoakZTcr7RQWaP
-        HALO-20240825a: QmdVXG9QTC1CiHGtpaV7Z4qPJVtDsgHY7E5mKR6rTHvPwP
-        HALO-20240827a: QmQ2UwRY3SSeUrxjpyFfYLgexn8vRNfU8SFwQRAUojgDK9
-        HALO-20240829a: QmSDMQMgbJPBTQ5N3EpJBXNTPoLVAh8LkRKkuSkuoYicd6
-        HALO-20240831a: QmZgqewSLMP7oM3t57fE4sZfBjXhoB5rjW84gHcrtaMQgd
-        HALO-20240903a: QmajkeRN7uHsWWbFiFAMit7dmbjXPsvBgsa8CduY7UTztG
-        HALO-20240906a: QmYfqDB87agZ5iLijcJurSwvTzYAhXh3ciKUmu8yip4vP7
-        HALO-20240907a: QmZi3eKFzNMdXYFA36KvNtMqqCC4viXQvR2Q4QCFxKmApc
-        HALO-20240909a: QmUmCFLx7EPAjcL1YtijBQ1mvbkC9ieWCnnnAoUJGU2ijR
-        HALO-20240912a: QmZHKFj6iMiysbUt9Ym9pc7pEZ1ycmNopoFPmJ2AGi3mbU
-        HALO-20240914a: QmVh6bzSJHvkuDPq2fCiBydtrqEYVEMqu2MrvkWEUWK6XY
-        HALO-20240916a: QmYc2G4AvYzmwyWapEZuNRQotY5xo8kRj4VxBgUbgBBYrq
-        HALO-20240919a: QmPcmGayUm5adQqnFE6igVUd1E4xR2wo7KZQeSe5rnrSUu
-        HALO-20240921a: Qmbnvb7YWebwzufSRrDxY8qZoso7PgcudTBBxXKmoTxCvH
-        HALO-20240923a: QmTE5s25hBL59SLpSmFdTc7oAVDwe2d5j3WzhR6AnV9kkR
-        HALO-20240924a: QmRD8Vk7dZybGVa2ZHfb37Mz1RU2qXjbPysFPpbqViBDHo
-        HALO-20240926a: QmUxra1YXWpCR4KpqGuFBBCTp4cgrB6Hg89z6bNXT7Sy2E
-        HALO-20240928a: QmPXPRNZAasLegjdJQKdVWff6jkQENLdH1oovbEXztPE2z
-      Level_4:
-        PERCUSION_Level_4.zarr: QmdncPxFxCwgkb2hVSxnf2rv1unUxPCAqEgkZv12mXNZoP
-      Level_3:
-        PERCUSION_Level_3.zarr: QmYDabZze7d5VeTcTzEBDHZbCeYgiYvCXkDVBKmg9TwNYS
-        PERCUSION_Level_3_qc.zarr: QmXjz7t1pcnbxVsdzfaWnNPpBrbNfPBM2Dhghsun1P2D32
+      Level_1: bafybeieezlchudamlslniz2zvoknqw76zyrotzapc47wy6l3ou7unwcvle
+      Level_2: bafybeifi5pglgpcq6onwb3yixhvghcmenkvqmcqi7qgjbrbqlgoyrvj52i
+      Level_4: bafybeicrhlyrk6lsrz5wmmlm7g5qin7rfhlnoauaky4ydpriiddp2x5jem
+      Level_3: bafybeiedd7nhvejqgszw26grskt7czw3zpgkzt37mnalp3uw5y2m3xiweq
+      Level_3_qc: bafybeibrn2mamdd7bkb7i6v2xbkiowoksuvbolvpq7udabegsgaqvejgp4
     flight_animations:
       HALO-20240811a.mp4: QmZq3bWjAAMnU96WzwG79aNdVDRJsiJYohaTX3ELGDUhfF
       HALO-20240813a.mp4: QmZvPRwxJS78imNvBxYaXZUGzggcywpN4TaXRQy3tJJruH
@@ -391,31 +341,7 @@ raw:
       HALO-20241114b: QmeEWMfE27U2rThzTkwqUXvb3ntHdjvCfqkknsDHry64Gr
       HALO-20241116a: QmSmfuDA1h67Q6cumizvjbsn2ex4gpsyUbFSWmTfbhRT53
       HALO-20241119a: QmYU8PF5AGHqzuPs8Wki8C8npFCyh5fNfRGx9ThVQ5qWYm
-    dropsondes:
-      HALO-20240809b: Qmbyg4KzddvFesPpEe2xtJA25QzknXZHdjvzdsWqwWafVg
-      HALO-20240811a: QmXpDQQ2LZp6CaCFBo9aeSgeXWZxbQ1Hy1XotZXjeY1XeS
-      HALO-20240813a: QmZtP8zKjdqoCAvveGKPSa58t3pRnbtJgcnVmxq8XbKxwL
-      HALO-20240816a: QmWzFro2zVw7hi9oVy1bGZagzkdQx5vFcq1Ap3dtPhk4Vf
-      HALO-20240818a: QmNoLxamntshr8Y3yneSKQs8h1VtfpdcTqmAfEdZwos2ep
-      HALO-20240821a: QmQZUK7GgNbjseXF3VEmTrKLkfraPBF7NLoMTFm13uRaoN
-      HALO-20240822a: QmUzThH9WWQHhyPx49bwBAR77cbCDCXZqQiHyRyYtxRZxK
-      HALO-20240825a: QmTYLkogQpiVv1rQ4B3dHuP3FawB3Xndv4ZZgu2mqV4irt
-      HALO-20240827a: QmNNKdXibv9oD3DrRKqD5UDug13ksDd44jxxMiyVsHPaL8
-      HALO-20240829a: QmbPRgzzHSGDv61Wv6N1pyZYzy6rpH9Gk1zbXCGauTmJZc
-      HALO-20240831a: QmckN5FUk1r4tJyKpvVts1jSS4ptvcihYQFkUFEsqvdKVM
-      HALO-20240903a: QmTE5hx6Q663XMskQaBpnvYVFLgjt34qexBNCWvtbLT5op
-      HALO-20240906a: QmWsTDwUWo2Lq87rfnAyNS2QAhS7FRcuDMD61TfWj4AVQY
-      HALO-20240907a: QmW7gowYoAy6Pdzy2mBUJCgCArpfUuEQnscDHMqgvhLKvd
-      HALO-20240909a: QmPP68csiQbv1kG2VQJfe9UNXLc8yx7NGsCFNfWBgzTvta
-      HALO-20240912a: QmTgBrSSs2cVGtSLCkaon7qsNFcimrK4DTtbMYhDQbkJav
-      HALO-20240914a: QmPQYyDDfYjGAG7BNS6P8xaZXwPSC2thoNKXZzdzUij1kh
-      HALO-20240916a: QmYZUpiJmGrybFKks5QjXnP2QKLE4wmz2HsXpibBC2BBE8
-      HALO-20240919a: QmQ6vpYvN7GYz4WpvWS3guGHdXmjJCcuyik8vG7eugg8Bz
-      HALO-20240921a: QmTta7ihuh5GzgdYAPqqrjPESfrQ9pyLnYHSMuhvuxTX3K
-      HALO-20240923a: Qmck36AvTxo4pL5bns2HrVYf4tvhzAfHs5r79z9uqQKttn
-      HALO-20240924a: QmXcdvtBfdipsDNsWb4qLM7nT7Dn15Xen4XqMN3fiPToia
-      HALO-20240926a: QmQJdk9Y5L4x28cec8vq14EHu6tvwvJVZK7ZmdUqBMQYef
-      HALO-20240928a: QmcLaASBJRkuSFZQbJrG8nmSZSS5tKkYvjZNHtinM2hqEa
+    dropsondes: bafybeidu7lurmigsvs6i775a7irxfhvpow6thskaoepj7dgewy3z5trxiu
   BCO:
     radiosondes: QmRjDCzXrRiVyZLxKK2pMFszqvWz6ZDvz3pZZUCNRtUBXC
   INMG:


### PR DESCRIPTION
I tried to write a Metadata.yaml as described [here](https://github.com/orcestra-campaign/ipfsui/issues/63)...

Maybe you can check if it works in the browser in principle, then we can check if it's sufficient? Then I wondered how to best put that CID in. It makes more sense to me to have one of them for the whole L1 and not one for each flight, but currently I give the CIDs by flight into the tree. 

I see two options:
- have the cid as I put it now as another "top-level-folder"; however it currently contains the full Level 1 data; so for this option I should probably put the metadata yaml with a separate cid? 
- remove the folder structure and have just one top-level CID. 

Do you have a preference? 