### PR TITLE
Fix sonde_id coordinate to depend on sonde_id dimension

### DIFF
--- a/tree.yaml
+++ b/tree.yaml
@@ -208,7 +208,7 @@ products:
     omega_SEVIRI.zarr: QmNxAG7p73BxCchb3NTv65drLJPqtKbG3ZxSoUuLLpY68P
   Radiosondes:
     Level_1:
-      RAPSODI_RS_ORCESTRA_level1.zarr: QmYM2oE9yya2hp6nfwn4hwvv8XhbLF4Svp2eLuthJMdMBb
+      RAPSODI_RS_ORCESTRA_level1.zarr: QmQDTy3yT2x5xvEGQbV8o8sYnkLo7LvAueLQ28gwCEZnXL
       RAPSODI_RS_METEOR_Oscillating_ORCESTRA_level1.zarr: QmezukkuPaiQK3bT8oJqQ5GLBpNYpqxJ7gWhwdpLuspsfh
     Level_2:
       RAPSODI_RS_ORCESTRA_level2.zarr: QmWthfrCzN1FboGUfnL7BkRoX65zveRdTrJD9DbspTUSBx


### PR DESCRIPTION
me again...

While fixing the sonde_id in level 1 I made it dependent on a false coordinate.
Here, now the corrected version.

.🚗-file can be found here:
```/work/mh0731/m300868/09_Orcestra/02_IPFS_car_files/QmQDTy3yT2x5xvEGQbV8o8sYnkLo7LvAueLQ28gwCEZnXL.car```

Thanks !